### PR TITLE
Allow before actions on update action for sections

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -2,8 +2,8 @@
 
 class SectionsController < ApplicationController
   load_and_authorize_resource
-  before_action :set_permissions, only: [:edit]
-  before_action :set_vlan, only: %i[new create edit]
+  before_action :set_permissions, only: %i[edit update]
+  before_action :set_vlan, only: %i[new create edit update]
 
   # GET /sections
   def index

--- a/changelog/unreleased/allow-before-actions-on-update-action-for-sections.yml
+++ b/changelog/unreleased/allow-before-actions-on-update-action-for-sections.yml
@@ -1,0 +1,4 @@
+---
+type: fixed
+title: Allow before actions on update action for sections
+merge_request: 166


### PR DESCRIPTION
Fix error:
```
netam_web   | 2020-11-30 15:18:17.812802 F [1:puma threadpool 004 debug_exceptions.rb:9] [["8bba9cac-4d35-4852-a747-b9f050b88c8f"]] Rails -- Exception: ActionView::Template::Error: undefined method `map' for nil:NilClass
```